### PR TITLE
Add support for URL objects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,8 +15,11 @@ filenamifyUrl('http://sindresorhus.com/foo?bar=baz');
 
 filenamifyUrl('http://sindresorhus.com/foo', {replacement: '🐴'});
 //=> 'sindresorhus.com🐴foo'
+
+filenamifyUrl(new URL('http://sindresorhus.com'));
+//=> 'sindresorhus.com'
 ```
 */
-export default function filenamifyUrl(url: string, options?: Options): string;
+export default function filenamifyUrl(url: string | URL, options?: Options): string;
 
 export {Options} from 'filenamify';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 import filenamify from 'filenamify';
 import humanizeUrl from 'humanize-url';
-import is from '@sindresorhus/is';
 
 export default function filenamifyUrl(url, options) {
 	if (!(typeof url === 'string' || url instanceof URL)) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ import humanizeUrl from 'humanize-url';
 import is from '@sindresorhus/is';
 
 export default function filenamifyUrl(url, options) {
-	if (typeof url !== 'string' && !is.urlInstance(url)) {
+	if (!(typeof url === 'string' || url instanceof URL)) {
 		throw new TypeError('Expected a string or URL instance');
 	}
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 import filenamify from 'filenamify';
 import humanizeUrl from 'humanize-url';
+import is from '@sindresorhus/is';
 
-export default function filenamifyUrl(string, options) {
-	if (typeof string !== 'string') {
-		throw new TypeError('Expected a string');
+export default function filenamifyUrl(url, options) {
+	if (typeof url !== 'string' && !is.urlInstance(url)) {
+		throw new TypeError('Expected a string or URL instance');
 	}
 
-	return filenamify(decodeURIComponent(humanizeUrl(string)), options);
+	return filenamify(decodeURIComponent(humanizeUrl(url.toString())), options);
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"url"
 	],
 	"dependencies": {
+		"@sindresorhus/is": "^6.1.0",
 		"filenamify": "^5.0.1",
 		"humanize-url": "^3.0.0"
 	},

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 		"url"
 	],
 	"dependencies": {
-		"@sindresorhus/is": "^6.1.0",
 		"filenamify": "^5.0.1",
 		"humanize-url": "^3.0.0"
 	},

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,6 @@ filenamifyUrl('http://sindresorhus.com/foo', {replacement: '🐴'});
 
 filenamifyUrl(new URL('http://sindresorhus.com'));
 //=> 'sindresorhus.com'
-
 ```
 
 ## API

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,10 @@ filenamifyUrl('http://sindresorhus.com/foo?bar=baz');
 
 filenamifyUrl('http://sindresorhus.com/foo', {replacement: '🐴'});
 //=> 'sindresorhus.com🐴foo'
+
+filenamifyUrl(new URL('http://sindresorhus.com'));
+//=> 'sindresorhus.com'
+
 ```
 
 ## API
@@ -28,7 +32,7 @@ Accepts a URL and returns a valid filename.
 
 #### url
 
-Type: `string`
+Type: `string | URL`
 
 A URL to convert to a valid filename.
 

--- a/test.js
+++ b/test.js
@@ -10,3 +10,10 @@ test('main', t => {
 	t.is(filenamifyUrl('sindresorhus.com/foo', {replacement: '🐴'}), 'sindresorhus.com🐴foo');
 	t.is(filenamifyUrl('http://www.sindresorhus.com/?query=pageres*|<>:"\\'), 'sindresorhus.com!query=pageres');
 });
+
+test('URLs', t => {
+	t.is(filenamifyUrl(new URL('http://user:pass@www.sindresorhus.com/foo/bar/')), 'sindresorhus.com!foo!bar');
+	t.is(filenamifyUrl(new URL('http://user@sindresorhus.com')), 'sindresorhus.com');
+	t.is(filenamifyUrl(new URL('http://www.sindresorhus.com/?query=pageres*|<>:"\\')), 'sindresorhus.com!query=pageres');
+});
+

--- a/test.js
+++ b/test.js
@@ -16,4 +16,3 @@ test('URLs', t => {
 	t.is(filenamifyUrl(new URL('http://user@sindresorhus.com')), 'sindresorhus.com');
 	t.is(filenamifyUrl(new URL('http://www.sindresorhus.com/?query=pageres*|<>:"\\')), 'sindresorhus.com!query=pageres');
 });
-


### PR DESCRIPTION
Seemed like this package should support URL objects as well as URL-ish strings. Also seemed appropriate to use your [is package](https://github.com/sindresorhus/is) for URL type-checking. 
